### PR TITLE
Fix output option for stdout (fixes #62)

### DIFF
--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -26,6 +26,10 @@ import sys
 from compiledb.parser import parse_build_log, Error
 
 
+def __is_stdout(compdb_path):
+    return not compdb_path or compdb_path == '-'
+
+
 def generate_json_compdb(instream=None, proj_dir=os.getcwd(), verbose=False, exclude_files=[]):
     if not os.path.isdir(proj_dir):
         raise Error("Project dir '{}' does not exists!".format(proj_dir))
@@ -37,16 +41,24 @@ def generate_json_compdb(instream=None, proj_dir=os.getcwd(), verbose=False, exc
 
 def write_json_compdb(compdb, compdb_path='compile_commands.json', verbose=False,
                       force=False, pretty_output=True):
-    print("## Writing compilation database with {} entries to {}".format(
-        len(compdb), compdb_path))
+    if not __is_stdout(compdb_path):
+        print("## Writing compilation database with {} entries to {}".format(
+            len(compdb), compdb_path))
 
-    with open(compdb_path, 'w') as outstream:
-        json.dump(compdb, outstream, indent=pretty_output)
-        outstream.write(os.linesep)
+        with open(compdb_path, 'w') as outstream:
+            json.dump(compdb, outstream, indent=pretty_output)
+            outstream.write(os.linesep)
+    else:
+        print("## Writing compilation database with {} entries to <stdout>".format(
+            len(compdb)))
+        print(json.dumps(compdb, indent=pretty_output))
 
 
 def load_json_compdb(compdb_path='compile_commands.json', verbose=False):
     try:
+        if __is_stdout(compdb_path):
+            return []
+
         with open(compdb_path, 'r') as instream:
             compdb = json.load(instream)
 

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -53,7 +53,7 @@ class Options(object):
 @click.option('-o', '--output', 'outfile', type=click.Path(),
               help="Output file path (Default: compile_commands.json). " +
               'If -f/--overwrite is not specified, this file is updated ' +
-              'with the new contents.',
+              'with the new contents. Use \'-\' to output to stdout',
               required=False, default='compile_commands.json')
 @click.option('-d', '--build-dir', 'build_dir', type=click.Path(),
               help="Path to be used as initial build dir", default=os.getcwd())

--- a/tests/test_json_compdb.py
+++ b/tests/test_json_compdb.py
@@ -21,7 +21,6 @@
 import os
 import shutil
 import json
-import re
 import pytest
 from compiledb import load_json_compdb, generate
 from tests.common import input_file, data_dir

--- a/tests/test_json_compdb.py
+++ b/tests/test_json_compdb.py
@@ -21,7 +21,7 @@
 import os
 import shutil
 import json
-import click
+import re
 import pytest
 from compiledb import load_json_compdb, generate
 from tests.common import input_file, data_dir
@@ -49,6 +49,7 @@ multiple_commands_oneline_compdb = [
     }
 ]
 nonexistent_files = ['compile_commands.json', 'nonexistent.json']
+stdout_filenames = ['-', '']
 
 
 def test_load_no_compdb_path_default_file_not_exist(capsys):
@@ -113,10 +114,16 @@ def test_load_compdb_path_file_exists(capsys):
     )
 
 
+@pytest.mark.parametrize('output_filename', stdout_filenames)
+def test_load_compdb_ignores_stdout_filename(capsys, output_filename):
+    assert load_json_compdb(output_filename, verbose=True) == []
+    assert capsys.readouterr().out == ''
+
+
 @pytest.mark.parametrize('output_filename', nonexistent_files)
 def test_generate_input_file_not_exist_no_overwrite(capsys, output_filename):
     assert_generate_is_true(output_filename, overwrite=False)
-    assert_compdb_equals(output_filename, multiple_commands_oneline_compdb)
+    assert_compdb_file_equals(output_filename, multiple_commands_oneline_compdb)
     output = capsys.readouterr().out
     assert 'Failed to read previous ' + output_filename in output
     assert 'Writing compilation database with 2 entries to ' + output_filename in output
@@ -125,7 +132,7 @@ def test_generate_input_file_not_exist_no_overwrite(capsys, output_filename):
 @pytest.mark.parametrize('output_filename', nonexistent_files)
 def test_generate_input_file_not_exist_overwrite(capsys, output_filename):
     assert_generate_is_true(output_filename, overwrite=True)
-    assert_compdb_equals(output_filename, multiple_commands_oneline_compdb)
+    assert_compdb_file_equals(output_filename, multiple_commands_oneline_compdb)
     output = capsys.readouterr().out
     assert 'Failed to read previous ' + output_filename not in output
     assert 'Writing compilation database with 2 entries to ' + output_filename in output
@@ -150,7 +157,7 @@ def test_generate_input_file_exists_no_overwrite(capsys):
             ]
         }
     ]
-    assert_compdb_equals(output_filename, expected_compdb)
+    assert_compdb_file_equals(output_filename, expected_compdb)
     output = capsys.readouterr().out
     assert 'Loaded compilation database with 1 entries from ' + output_filename in output
     assert 'Writing compilation database with 3 entries to ' + output_filename in output
@@ -163,10 +170,30 @@ def test_generate_input_file_exists_overwrite(capsys):
 
     assert_generate_is_true(output_filename, overwrite=True)
 
-    assert_compdb_equals(output_filename, multiple_commands_oneline_compdb)
+    assert_compdb_file_equals(output_filename, multiple_commands_oneline_compdb)
     output = capsys.readouterr().out
     assert 'Loaded compilation database with 1 entries from ' + output_filename not in output
     assert 'Writing compilation database with 2 entries to ' + output_filename in output
+
+
+@pytest.mark.parametrize('output_filename', ['-', ''])
+@pytest.mark.parametrize('overwrite', [False, True])
+def test_generate_output_stdout(capsys, output_filename, overwrite):
+    try:
+        assert_generate_is_true(output_filename, overwrite=overwrite)
+        assert not os.path.exists(output_filename)
+        output = capsys.readouterr().out
+        assert 'Writing compilation database with 2 entries to <stdout>' in output
+        
+        # Find where the JSON file starts and ends and decode it
+        start_index = output.index('[')
+        end_index = output.rindex(']') + 1
+        compdb = json.loads(output[start_index:end_index])
+
+        assert_compdb_equals(compdb, multiple_commands_oneline_compdb)
+    finally:
+        if os.path.exists(output_filename):
+            os.remove(output_filename)
 
 
 def assert_generate_is_true(output_filename, overwrite):
@@ -181,14 +208,21 @@ def assert_generate_is_true(output_filename, overwrite):
             strict=False
         )
 
-def assert_compdb_equals(compdb_path, expected_compdb):
+def assert_compdb_file_equals(compdb_path, expected_compdb):
     def get_key(item):
         return item['directory'], item['file'], item['arguments']
 
     try:
         with open(compdb_path, 'r') as instream:
             compdb = json.load(instream)
-            assert sorted(compdb, key=get_key) == sorted(expected_compdb, key=get_key)
+            assert_compdb_equals(compdb, expected_compdb)
     finally:
         if os.path.exists(compdb_path):
             os.remove(compdb_path)
+
+
+def assert_compdb_equals(compdb, expected_compdb):
+    def get_key(item):
+        return item['directory'], item['file'], item['arguments']
+
+    assert sorted(compdb, key=get_key) == sorted(expected_compdb, key=get_key)

--- a/tests/test_json_compdb.py
+++ b/tests/test_json_compdb.py
@@ -208,9 +208,6 @@ def assert_generate_is_true(output_filename, overwrite):
         )
 
 def assert_compdb_file_equals(compdb_path, expected_compdb):
-    def get_key(item):
-        return item['directory'], item['file'], item['arguments']
-
     try:
         with open(compdb_path, 'r') as instream:
             compdb = json.load(instream)


### PR DESCRIPTION
* PR #61 broke the ability to specify stdout for `-o/--output`. This PR fixes that
* Added tests for `-o/--output` for stdout