### PR TITLE
Implement Click.File approach for output option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 # mypy
 .mypy_cache/
 
+# vim-related
+*.swp
+*.swo

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -50,7 +50,7 @@ class Options(object):
 @click.option('-p', '--parse', 'infile', type=click.File('r'),
               help='Build log file to parse compilation commands from.' +
               '(Default: stdin)', required=False, default=sys.stdin)
-@click.option('-o', '--output', 'outfile', type=click.Path(),
+@click.option('-o', '--output', 'outfile', type=click.File('a+'),
               help="Output file path (Default: compile_commands.json). " +
               'If -f/--overwrite is not specified, this file is updated ' +
               'with the new contents. Use \'-\' to output to stdout',

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,6 @@
 attrs==18.1.0
 bashlex==0.12
-click==6.7
+click==7.0
 enum34==1.1.6
 more-itertools==4.1.0
 pluggy==0.6.0

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,6 +23,15 @@ from os import path
 data_dir = path.abspath(path.join(path.dirname(__file__), 'data'))
 
 
+def full_path(relpath):
+    return path.join(data_dir, relpath)
+
+
 def input_file(relpath):
-    relpath = '{}.txt'.format(relpath)
-    return open(path.join(data_dir, relpath), 'r')
+    relpath = '{}'.format(relpath)
+    return open(full_path(relpath), 'r')
+
+
+def output_file(relpath):
+    relpath = '{}'.format(relpath)
+    return open(full_path(relpath), 'a+')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -151,7 +151,7 @@ def test_parse_with_non_build_cmd_entries():
 
 def test_automake_command():
     pwd = getcwd()
-    with input_file('autotools_simple') as build_log:
+    with input_file('autotools_simple.txt') as build_log:
         result = parse_build_log(
             build_log,
             proj_dir=pwd,
@@ -180,7 +180,7 @@ def test_automake_command():
 
 def test_multiple_commands_per_line():
     pwd = getcwd()
-    with input_file('multiple_commands_oneline') as build_log:
+    with input_file('multiple_commands_oneline.txt') as build_log:
         result = parse_build_log(
             build_log,
             proj_dir=pwd,


### PR DESCRIPTION
Based on @rzuckerm's branch, I managed to make compiledb work with the Click.File approach.

There were some changes in order to make this approach work:

- Click needs to be 7.0, because of a [bug](https://github.com/pallets/click/issues/776) that wouldn't allow using <stdout> when "-" is passed as command-line param for "w+" and "a+" file types
- Outfiles are file streams instead of file paths
- stdout checking still needs some improvements because of the way pytest handles stdout capture