### PR TITLE
Cleanups for macOS X and enable --command-style option

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
-ignore = E501
+ignore = E226, W504
+max-line-length = 120
 exclude =
     .git,
     __pycache__
-

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ compiledb -n make
 from arbitrary text files (or stdin), assuming it has a build log (ideally generated using
 `make -Bnwk` command), and generates the corresponding JSON Compilation database.
 
-For example, to generate the compilation database  from `build-log.txt` file, use the following
+For example, to generate the compilation database from `build-log.txt` file, use the following
 command.
 ```bash
 $ compiledb --parse build-log.txt
@@ -72,6 +72,13 @@ Or even, to pipe make's output and print the compilation database to the standar
 $ make -Bnwk | compiledb -o-
 ```
 
+By default `compiledb` generates a JSON compilation database in the "arguments" list
+[format](https://clang.llvm.org/docs/JSONCompilationDatabase.html). The "command" string
+format is also supported through the use of the `--command-style` flag:
+```bash
+$ compiledb --command-style make
+```
+
 ## Testing / Contributing
 
 I've implemented this tool because I needed to index some [AOSP][aosp]'s modules for navigating
@@ -83,10 +90,12 @@ could use it with some great tools, such as:
 
 - [Vim][vim] + [YouCompleteMe][ycm] + [rtags][rtags] + [chromatica.nvim][chrom]
 - [Neovim][neovim] + [LanguageClient-neovim][lsp] + [cquery][cquery] + [deoplete][deoplete]
+- [Neovim][neovim] + [ALE][ale] + [ccls][ccls]
 
 Notice:
 - _Windows: tested on Windows 10 with cmd, wsl(Ubuntu), mingw32_
-- _Linux: tested only on Arch Linux so far_
+- _Linux: tested only on Arch Linux and Ubuntu 18 so far_
+- _Mac: tested on macOS 10.13 and 10.14_
 
 Patches are always welcome :)
 
@@ -106,3 +115,5 @@ GNU GPLv3
 [lsp]: https://github.com/autozimu/LanguageClient-neovim
 [cquery]: https://github.com/cquery-project/cquery
 [deoplete]: https://github.com/Shougo/deoplete.nvim
+[ccls]: https://github.com/MaskRay/ccls
+[ale]: https://github.com/w0rp/ale

--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -39,12 +39,12 @@ def basename(stream):
         return os.path.basename(stream.name)
 
 
-def generate_json_compdb(instream=None, proj_dir=os.getcwd(), verbose=False, exclude_files=[]):
+def generate_json_compdb(instream=None, proj_dir=os.getcwd(), verbose=False, exclude_files=[], command_style=False):
     if not os.path.isdir(proj_dir):
         raise Error("Project dir '{}' does not exists!".format(proj_dir))
 
     print("## Processing build commands from {}".format(basename(instream)))
-    result = parse_build_log(instream, proj_dir, exclude_files, verbose)
+    result = parse_build_log(instream, proj_dir, exclude_files, verbose, command_style=command_style)
     return result
 
 
@@ -93,9 +93,10 @@ def merge_compdb(compdb, new_compdb, check_files=True, verbose=False):
     return [v for k, v in orig.items() if check_file(k)]
 
 
-def generate(infile, outfile, build_dir, exclude_files, verbose, overwrite=False, strict=False):
+def generate(infile, outfile, build_dir, exclude_files, verbose, overwrite=False, strict=False, command_style=False):
     try:
-        r = generate_json_compdb(infile, proj_dir=build_dir, verbose=verbose, exclude_files=exclude_files)
+        r = generate_json_compdb(infile, proj_dir=build_dir, verbose=verbose, exclude_files=exclude_files,
+                                 command_style=command_style)
         compdb = [] if overwrite else load_json_compdb(outfile, verbose)
         compdb = merge_compdb(compdb, r.compdb, strict, verbose)
         write_json_compdb(compdb, outfile, verbose=verbose)

--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -27,7 +27,7 @@ from compiledb.parser import parse_build_log, Error
 
 def __is_stdout(pfile):
     try:
-        return pfile.name == sys.stdout.name
+        return pfile.name == sys.stdout.name or isinstance(pfile.name, int)
     except:
         return pfile == sys.stdout
 

--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -28,7 +28,7 @@ from compiledb.parser import parse_build_log, Error
 def __is_stdout(pfile):
     try:
         return pfile.name == sys.stdout.name or isinstance(pfile.name, int)
-    except:
+    except AttributeError:
         return pfile == sys.stdout
 
 

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -35,7 +35,7 @@ class Options(object):
     shared by all compiledb subcommands"""
 
     def __init__(self, infile, outfile, build_dir, exclude_files, no_build,
-                 verbose, overwrite, strict):
+                 verbose, overwrite, strict, command_style):
         self.infile = infile
         self.outfile = outfile
         self.build_dir = build_dir
@@ -44,6 +44,7 @@ class Options(object):
         self.no_build = no_build
         self.overwrite = overwrite
         self.strict = strict
+        self.command_style = command_style
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
@@ -67,17 +68,20 @@ class Options(object):
               help='Overwrite compile_commands.json instead of just updating it.')
 @click.option('-S', '--no-strict', is_flag=True, default=False,
               help='Do not check if source files exist in the file system.')
+@click.option('--command-style', is_flag=True, default=False,
+              help='Output compilation database with single "command" '
+              'string rather than the default "arguments" list of strings.')
 @click.pass_context
-def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, no_strict):
+def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, no_strict, command_style):
     """Clang's Compilation Database generator for make-based build systems.
        When no subcommand is used it will parse build log/commands and generates
        its corresponding Compilation database."""
     if ctx.invoked_subcommand is None:
-        done = generate(infile, outfile, build_dir, exclude_files, verbose, overwrite, not no_strict)
+        done = generate(infile, outfile, build_dir, exclude_files, verbose, overwrite, not no_strict, command_style)
         exit(0 if done else 1)
     else:
-        ctx.obj = Options(infile, outfile, build_dir, exclude_files,
-                          no_build, verbose, overwrite, not no_strict)
+        ctx.obj = Options(infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, not no_strict,
+                          command_style)
 
 
 # Add subcommands

--- a/compiledb/commands/make.py
+++ b/compiledb/commands/make.py
@@ -9,10 +9,10 @@ from sys import exit, stdout, stderr, version_info
 from compiledb import generate
 
 
-if version_info[0] >= 3:  # Python 3
+if version_info.major >= 3 and version_info.minor >= 6:
     def popen(cmd, encoding='utf-8', **kwargs):
         return Popen(cmd, encoding=encoding, **kwargs)
-else:  # Python 2
+else:  # Python 2 and Python <= 3.5
     def popen(cmd, encoding='utf-8', **kwargs):
         return Popen(cmd, **kwargs)
 
@@ -99,7 +99,7 @@ def command(ctx, make_cmd, make_args):
         cmd = [make_cmd, logging_mode_flags] + list(make_args)
         if mock_script.path:
             cmd.append("SHELL={}".format(mock_script.path))
-        pipe = popen(cmd, stdout=PIPE, encoding='utf-8')
+        pipe = popen(cmd, stdout=PIPE)
         options.infile = pipe.stdout
         done = generate(**args)
         pipe.wait()

--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -42,8 +42,7 @@ class ParsingResult(object):
         self.compdb = []
 
     def __str__(self):
-        return "Line count: {}, Skipped: {}, Entries: {}".format(
-            self.count, self.skipped, str(self.compdb))
+        return "Line count: {}, Skipped: {}, Entries: {}".format(self.count, self.skipped, str(self.compdb))
 
 
 class Error(Exception):
@@ -54,7 +53,7 @@ class Error(Exception):
         return "Error: {}".format(self.msg)
 
 
-def parse_build_log(build_log, proj_dir, exclude_files, verbose, extra_wrappers=[]):
+def parse_build_log(build_log, proj_dir, exclude_files, verbose, command_style=False, extra_wrappers=[]):
     result = ParsingResult()
 
     def skip_line(cmd, reason):
@@ -131,15 +130,23 @@ def parse_build_log(build_log, proj_dir, exclude_files, verbose, extra_wrappers=
             # add entry to database
             tokens = c['tokens']
             arguments = [unescape(a) for a in tokens[len(wrappers):]]
+            command_str = ' '.join(arguments)
 
             if (verbose):
-                print("Adding command {}: {}".format(len(result.compdb), " ".join(arguments)))
+                print("Adding command {}: {}".format(len(result.compdb), command_str))
 
-            result.compdb.append({
-                'directory': working_dir,
-                'arguments': arguments,
-                'file': filepath,
-            })
+            if command_style:
+                result.compdb.append({
+                    'directory': working_dir,
+                    'command': command_str,
+                    'file': filepath,
+                })
+            else:
+                result.compdb.append({
+                    'directory': working_dir,
+                    'arguments': arguments,
+                    'file': filepath,
+                })
 
     return result
 

--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -25,14 +25,14 @@ from sys import version_info
 
 
 # Internal variables used to parse build log entries
-cc_compile_regex = re.compile("^.*-?g?cc$|^.*-?clang-?[0-9.]*$")
-cpp_compile_regex = re.compile("^.*-?[gc]\+\+$|^.*-?clang\+\+-?[0-9.]*$")
-file_regex = re.compile("^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.s$", re.IGNORECASE)
+cc_compile_regex = re.compile(r"^.*-?g?cc$|^.*-?clang-?[0-9.]*$")
+cpp_compile_regex = re.compile(r"^.*-?[gc]\+\+$|^.*-?clang\+\+-?[0-9.]*$")
+file_regex = re.compile(r"^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.s$", re.IGNORECASE)
 compiler_wrappers = {"ccache", "icecc", "sccache"}
 
 # Leverage `make --print-directory` option
-make_enter_dir = re.compile("^\s*make\[\d+\]: Entering directory [`\'\"](?P<dir>.*)[`\'\"]\s*$")
-make_leave_dir = re.compile("^\s*make\[\d+\]: Leaving directory .*$")
+make_enter_dir = re.compile(r"^\s*make\[\d+\]: Entering directory [`\'\"](?P<dir>.*)[`\'\"]\s*$")
+make_leave_dir = re.compile(r"^\s*make\[\d+\]: Leaving directory .*$")
 
 
 class ParsingResult(object):

--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -66,7 +66,7 @@ def parse_build_log(build_log, proj_dir, exclude_files, verbose, command_style=F
         try:
             exclude_files = "|".join(exclude_files)
             exclude_files_regex = re.compile(exclude_files)
-        except:
+        except re.error:
             raise Error('Exclude files regex not valid: {}'.format(exclude_files))
 
     compiler_wrappers.update(extra_wrappers)

--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -242,10 +242,10 @@ def unescape(s):
     return s.encode().decode('unicode_escape')
 
 
-if version_info[0] >= 3:  # Python 3
+if version_info.major >= 3 and version_info.minor >= 6:
     def run_cmd(cmd, encoding='utf-8', **kwargs):
         return subprocess.check_output(cmd, encoding=encoding, **kwargs)
-else:  # Python 2
+else:  # Python 2 and Python <= 3.5
     def run_cmd(cmd, encoding='utf-8', **kwargs):
         return subprocess.check_output(cmd, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'dev': [],
         'test': ['pytest'],
     },
-    python_requires='>=2.7',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
     entry_points={
         'console_scripts': [
             'compiledb=compiledb.cli:cli',

--- a/tests/data/multiple_commands_oneline.txt
+++ b/tests/data/multiple_commands_oneline.txt
@@ -1,2 +1,2 @@
-if true; then g++ -c "./path/src/`echo -n "hein$(echo -n '.cpp')"`" -o out.o; else echo 'aeeee'; fi
+if true; then g++ -c "./path/src/`/bin/echo -n "hein$(/bin/echo -n '.cpp')"`" -o out.o; else echo 'aeeee'; fi
 gcc -c -o main.o main.c || echo 'mucho loko'; if test -d fulano; then echo 'blz fera'; fi

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -200,6 +200,36 @@ def test_multiple_commands_per_line():
         ]
     }
 
+def test_multiple_commands_per_line_command_style():
+    """Test the command_style option using the multiple_commands_oneline.txt build log.
+    """
+    cwd = getcwd()
+
+    with input_file('multiple_commands_oneline.txt') as build_log:
+        result = parse_build_log(
+            build_log,
+            proj_dir=cwd,
+            exclude_files=[],
+            verbose=False,
+            command_style=True,
+        )
+
+    assert result.count == 2
+    assert result.skipped == 0
+    assert result.compdb == [
+        {
+            'command': 'g++ -c ./path/src/hein.cpp -o out.o',
+            'directory': cwd,
+            'file': './path/src/hein.cpp',
+        },
+        {
+            'command': 'gcc -c -o main.o main.c',
+            'directory': cwd,
+            'file': 'main.c',
+        }
+    ]
+
+
 def test_parse_file_extensions():
     pwd = getcwd()
     build_log = [

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py27,py36,lint
 
 [pycodestyle]
-ignore = E226, E722, W504, W605
+ignore = E226, W504
 max-line-length = 120
 exclude = tests
 


### PR DESCRIPTION
This PR combines a few different suggested improvements. I'd be happy to split this into smaller more atomic pull requests if you prefer.

My main goal was to provide a `--command-style` argument to the CLI such that the single string `"command": "..."` format for the JSON Compilation Database spec would be supported. I recently wished to have this option when using `compiledb` with the `ALE` vim plugin, which expects `compile_commands.json` files to use `"command"` rather than `"arguments"` format. This functionality is added in [8b652d8](https://github.com/nickdiego/compiledb/commit/8b652d885d0e1cb8d79ba5ad7058db7d1b420d57).

I added a fix for the `__is_stdout` function and modified the `multiple_commands_oneline.txt` file so that the tests would pass on macOS. The commit message in [753798a](https://github.com/nickdiego/compiledb/commit/753798a06968c9dcaf25253824ab85ce0cd23066) details why this change is required and describes a possible alternative change to the parser that would accomplish the same portability.

The remaining commits are largely cosmetic but aim to make the code slightly more robust to other versions of Python and remove some errors/warnings.