### PR TITLE
Configure logging levels and log format

### DIFF
--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -23,6 +23,7 @@
 import click
 import os
 import sys
+import logging
 
 from . import generate
 from .commands import make
@@ -76,6 +77,8 @@ def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overw
     """Clang's Compilation Database generator for make-based build systems.
        When no subcommand is used it will parse build log/commands and generates
        its corresponding Compilation database."""
+    log_level = logging.DEBUG if verbose else logging.ERROR
+    logging.basicConfig(level=log_level, format=None)
     if ctx.invoked_subcommand is None:
         done = generate(infile, outfile, build_dir, exclude_files, verbose, overwrite, not no_strict, command_style)
         exit(0 if done else 1)

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -80,7 +80,7 @@ def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overw
     log_level = logging.DEBUG if verbose else logging.ERROR
     logging.basicConfig(level=log_level, format=None)
     if ctx.invoked_subcommand is None:
-        done = generate(infile, outfile, build_dir, exclude_files, verbose, overwrite, not no_strict, command_style)
+        done = generate(infile, outfile, build_dir, exclude_files, overwrite, not no_strict, command_style)
         exit(0 if done else 1)
     else:
         ctx.obj = Options(infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, not no_strict,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,9 +28,8 @@ def test_empty():
     build_log = ''
     proj_dir = '/tmp'
     exclude_files = []
-    verbose = False
 
-    result = parse_build_log(build_log, proj_dir, exclude_files, verbose)
+    result = parse_build_log(build_log, proj_dir, exclude_files)
     assert result.count == 0
     assert result.skipped == 0
     assert result.compdb is not None
@@ -44,8 +43,7 @@ def test_trivial_build_command():
     result = parse_build_log(
         build_log,
         proj_dir=pwd,
-        exclude_files=[],
-        verbose=False)
+        exclude_files=[])
 
     assert result.count == 1
     assert result.skipped == 0
@@ -63,8 +61,7 @@ def test_build_commands_with_version():
     result = parse_build_log(
         build_log,
         proj_dir=pwd,
-        exclude_files=[],
-        verbose=False)
+        exclude_files=[])
 
     assert result.count == 1
     assert result.skipped == 0
@@ -87,8 +84,7 @@ def test_build_commands_with_wrapper():
     result = parse_build_log(
         build_log,
         proj_dir=pwd,
-        exclude_files=[],
-        verbose=True)
+        exclude_files=[])
 
     assert result.count == 4
     assert result.skipped == 0
@@ -132,8 +128,7 @@ def test_parse_with_non_build_cmd_entries():
     result = parse_build_log(
         build_log,
         proj_dir=pwd,
-        exclude_files=[],
-        verbose=True)
+        exclude_files=[])
 
     assert result.count == 2
     assert result.skipped == 6
@@ -155,8 +150,7 @@ def test_automake_command():
         result = parse_build_log(
             build_log,
             proj_dir=pwd,
-            exclude_files=[],
-            verbose=False)
+            exclude_files=[])
 
     assert result.count == 1
     assert result.skipped == 0
@@ -184,8 +178,7 @@ def test_multiple_commands_per_line():
         result = parse_build_log(
             build_log,
             proj_dir=pwd,
-            exclude_files=[],
-            verbose=False)
+            exclude_files=[])
 
     assert result.count == 2
     assert result.skipped == 0
@@ -210,7 +203,6 @@ def test_multiple_commands_per_line_command_style():
             build_log,
             proj_dir=cwd,
             exclude_files=[],
-            verbose=False,
             command_style=True,
         )
 
@@ -242,8 +234,7 @@ def test_parse_file_extensions():
     result = parse_build_log(
         build_log,
         proj_dir=pwd,
-        exclude_files=[],
-        verbose=True)
+        exclude_files=[])
 
     assert result.count == 5
     assert result.skipped == 0

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,9 @@ exclude = tests
 [pytest]
 testpaths = tests
 addopts = --junitxml=test-report.xml
+log_level = DEBUG
+log_format = %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
 
 [testenv]
 commands =


### PR DESCRIPTION
In this patchset, we are now able to configure how we want the logging to be done:

- The -l / --log-level is an enum for python's logging levels, with the addition of silent mode, which is 1 level higher than critical, so it won't log anything
- The -f / --log-format received a string to determine the log output format. If needed, we can add a --log-date-format to format the asctime as well
- All logs, according to the basicConfig factory, are printed to stderr
- These logs are using [Python's logging API](https://docs.python.org/3/library/logging.html), running also in Python 2
- Update tests to reflect the changes