### PR TITLE
Fixed "make" command.

### DIFF
--- a/compiledb/commands/make.py
+++ b/compiledb/commands/make.py
@@ -101,6 +101,7 @@ def command(ctx, make_cmd, make_args):
             cmd.append("SHELL={}".format(mock_script.path))
         pipe = popen(cmd, stdout=PIPE)
         options.infile = pipe.stdout
+        del args['verbose']
         done = generate(**args)
         pipe.wait()
     exit(0 if done else 1)


### PR DESCRIPTION
Commit 5bae1050b removed the "verbose" parameter at various places, so we
have to remove it from the keyword arguments passed to "generate()",
otherwise we will get a TypeError.