### PR TITLE
Fixed Issue #47 - Support skipping compiler flags through a regex

### DIFF
--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -42,12 +42,12 @@ def basename(stream):
         return os.path.basename(stream.name)
 
 
-def generate_json_compdb(instream=None, proj_dir=os.getcwd(), exclude_files=[], command_style=False):
+def generate_json_compdb(instream=None, proj_dir=os.getcwd(), exclude_files=[], exclude_args=[], command_style=False):
     if not os.path.isdir(proj_dir):
         raise Error("Project dir '{}' does not exists!".format(proj_dir))
 
     logger.info("## Processing build commands from {}".format(basename(instream)))
-    result = parse_build_log(instream, proj_dir, exclude_files, command_style=command_style)
+    result = parse_build_log(instream, proj_dir, exclude_files, exclude_args, command_style=command_style)
     return result
 
 
@@ -94,10 +94,10 @@ def merge_compdb(compdb, new_compdb, check_files=True):
     return [v for k, v in orig.items() if check_file(k)]
 
 
-def generate(infile, outfile, build_dir, exclude_files, overwrite=False, strict=False,
-             command_style=False):
+def generate(infile, outfile, build_dir, exclude_files, exclude_args,
+             overwrite=False, strict=False, command_style=False):
     try:
-        r = generate_json_compdb(infile, proj_dir=build_dir, exclude_files=exclude_files, command_style=command_style)
+        r = generate_json_compdb(infile, proj_dir=build_dir, exclude_files=exclude_files, exclude_args=exclude_args, command_style=command_style)
         compdb = [] if overwrite else load_json_compdb(outfile)
         compdb = merge_compdb(compdb, r.compdb, strict)
         write_json_compdb(compdb, outfile)

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -35,12 +35,13 @@ class Options(object):
     """ Simple data class used to store command line options
     shared by all compiledb subcommands"""
 
-    def __init__(self, infile, outfile, build_dir, exclude_files, no_build,
-                 verbose, overwrite, strict, command_style):
+    def __init__(self, infile, outfile, build_dir, exclude_files, exclude_args,
+                 no_build, verbose, overwrite, strict, command_style):
         self.infile = infile
         self.outfile = outfile
         self.build_dir = build_dir
         self.exclude_files = exclude_files
+        self.exclude_args = exclude_args
         self.verbose = verbose
         self.no_build = no_build
         self.overwrite = overwrite
@@ -61,6 +62,8 @@ class Options(object):
               help="Path to be used as initial build dir", default=os.getcwd())
 @click.option('-e', '--exclude', 'exclude_files', multiple=True,
               help="Regular expressions to exclude files.")
+@click.option('-x', '--exclude-args', 'exclude_args', multiple=True,
+              help="Regular expressions to exclude arguments.")
 @click.option('-n', '--no-build', is_flag=True, default=False,
               help='Only generates compilation db file.')
 @click.option('-v', '--verbose', is_flag=True, default=False,
@@ -73,17 +76,17 @@ class Options(object):
               help='Output compilation database with single "command" '
               'string rather than the default "arguments" list of strings.')
 @click.pass_context
-def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, no_strict, command_style):
+def cli(ctx, infile, outfile, build_dir, exclude_files, exclude_args, no_build, verbose, overwrite, no_strict, command_style):
     """Clang's Compilation Database generator for make-based build systems.
        When no subcommand is used it will parse build log/commands and generates
        its corresponding Compilation database."""
     log_level = logging.DEBUG if verbose else logging.ERROR
     logging.basicConfig(level=log_level, format=None)
     if ctx.invoked_subcommand is None:
-        done = generate(infile, outfile, build_dir, exclude_files, overwrite, not no_strict, command_style)
+        done = generate(infile, outfile, build_dir, exclude_files, exclude_args, overwrite, not no_strict, command_style)
         exit(0 if done else 1)
     else:
-        ctx.obj = Options(infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, not no_strict,
+        ctx.obj = Options(infile, outfile, build_dir, exclude_files, exclude_args, no_build, verbose, overwrite, not no_strict,
                           command_style)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -261,3 +261,37 @@ def test_parse_file_extensions():
         'arguments': ['gcc', '-c', '-o', 'what.o', 'what.s']
     }]
 
+
+def test_exclude_arguments():
+    pwd = getcwd()
+    build_log = [
+        'gcc -c somefile.cpp\n'
+        'gcc -fso-long-and-thanks-for-all-the-fish -c main.cxx -o main.o\n'
+        'gcc -Wall -Werror -W12345-i-can-eat-a-fish-alive -c main.cc -o main.o\n'
+        'gcc -fish -c pond.c -o pond.o\n'
+        ]
+    result = parse_build_log(
+        build_log,
+        proj_dir=pwd,
+        exclude_args=['.+fish.*', '-Werror'])
+
+    assert result.count == 4
+    assert result.skipped == 0
+    assert len(result.compdb) == 4
+    assert result.compdb == [{
+        'directory': pwd,
+        'file': 'somefile.cpp',
+        'arguments': ['gcc', '-c', 'somefile.cpp']
+    }, {
+        'directory': pwd,
+        'file': 'main.cxx',
+        'arguments': ['gcc', '-c', 'main.cxx', '-o', 'main.o'],
+    }, {
+        'directory': pwd,
+        'file': 'main.cc',
+        'arguments': ['gcc', '-c', 'main.cc', '-o', 'main.o'],
+    }, {
+        'directory': pwd,
+        'file': 'pond.c',
+        'arguments': ['gcc', '-fish', '-c', 'pond.c', '-o', 'pond.o'],
+    }]


### PR DESCRIPTION
Added `--exclude-args` (`-x`) option that lets you specify one or more regular expressions that, if matched, suppress the matching command line option(s).  Expression matching happens at the beginning of the argument.