### PR TITLE
Avoid spurious error messages caused by substitution attempts.

### DIFF
--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -35,6 +35,9 @@ compiler_wrappers = {"ccache", "icecc", "sccache"}
 make_enter_dir = re.compile(r"^\s*make\[\d+\]: Entering directory [`\'\"](?P<dir>.*)[`\'\"]\s*$")
 make_leave_dir = re.compile(r"^\s*make\[\d+\]: Leaving directory .*$")
 
+# We want to skip such lines from configure to avoid spurious MAKE expansion errors.
+checking_make = re.compile(r"^checking whether .* sets \$\(\w+\)\.\.\. (yes|no)$")
+
 logger = logging.getLogger(__name__)
 
 
@@ -98,6 +101,8 @@ def parse_build_log(build_log, proj_dir, exclude_files, command_style=False, add
         if (make_leave_dir.match(line)):
             dir_stack.pop()
             working_dir = dir_stack[-1]
+            continue
+        if (checking_make.match(line)):
             continue
 
         commands = []


### PR DESCRIPTION
The CommandProcessor gets confused by configure output lines of the form:

    checking whether make sets $(MAKE)... yes

It tries to make a command substitution by calling a comannd MAKE, which
most likely will fail and doesn't make sense at all.  While this doesn't
really hurt, it is confusing to see lines of the form

    /bin/sh: 1: MAKE: not found

on stderr when running compiledb.  We now simply skip such lines, avoiding
the above error message.  Admittedly this is a very special case, but a very
common one, so we better handle it.