### PR TITLE
Add --macro and --full-path parameters

### DIFF
--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -23,7 +23,9 @@ import json
 import os
 import sys
 import logging
+
 from compiledb.parser import parse_build_log, Error
+
 
 logger = logging.getLogger(__name__)
 
@@ -42,12 +44,14 @@ def basename(stream):
         return os.path.basename(stream.name)
 
 
-def generate_json_compdb(instream=None, proj_dir=os.getcwd(), exclude_files=[], command_style=False):
+def generate_json_compdb(instream=None, proj_dir=os.getcwd(), exclude_files=[], add_predefined_macros=False,
+                         use_full_path=False, command_style=False):
     if not os.path.isdir(proj_dir):
         raise Error("Project dir '{}' does not exists!".format(proj_dir))
 
     logger.info("## Processing build commands from {}".format(basename(instream)))
-    result = parse_build_log(instream, proj_dir, exclude_files, command_style=command_style)
+    result = parse_build_log(instream, proj_dir, exclude_files, add_predefined_macros=add_predefined_macros,
+                             use_full_path=use_full_path, command_style=command_style)
     return result
 
 
@@ -95,9 +99,11 @@ def merge_compdb(compdb, new_compdb, check_files=True):
 
 
 def generate(infile, outfile, build_dir, exclude_files, overwrite=False, strict=False,
-             command_style=False):
+             add_predefined_macros=False, use_full_path=False, command_style=False):
     try:
-        r = generate_json_compdb(infile, proj_dir=build_dir, exclude_files=exclude_files, command_style=command_style)
+        r = generate_json_compdb(infile, proj_dir=build_dir, exclude_files=exclude_files,
+                                 add_predefined_macros=add_predefined_macros, use_full_path=use_full_path,
+                                 command_style=command_style)
         compdb = [] if overwrite else load_json_compdb(outfile)
         compdb = merge_compdb(compdb, r.compdb, strict)
         write_json_compdb(compdb, outfile)

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -36,7 +36,7 @@ class Options(object):
     shared by all compiledb subcommands"""
 
     def __init__(self, infile, outfile, build_dir, exclude_files, no_build,
-                 verbose, overwrite, strict, command_style):
+                 verbose, overwrite, strict, add_predefined_macros, use_full_path, command_style):
         self.infile = infile
         self.outfile = outfile
         self.build_dir = build_dir
@@ -45,6 +45,8 @@ class Options(object):
         self.no_build = no_build
         self.overwrite = overwrite
         self.strict = strict
+        self.add_predefined_macros = add_predefined_macros
+        self.use_full_path = use_full_path
         self.command_style = command_style
 
 
@@ -69,22 +71,29 @@ class Options(object):
               help='Overwrite compile_commands.json instead of just updating it.')
 @click.option('-S', '--no-strict', is_flag=True, default=False,
               help='Do not check if source files exist in the file system.')
+@click.option('-m', '--macros', 'add_predefined_macros', is_flag=True, default=False,
+              help='Add predefined compiler macros to the compilation database. Make sure that ' +
+              'all of the used compilers are in your $PATH')
+@click.option('--full-path', 'use_full_path', is_flag=True, default=False,
+              help='Write full path to the compiler executable.')
 @click.option('--command-style', is_flag=True, default=False,
               help='Output compilation database with single "command" '
               'string rather than the default "arguments" list of strings.')
 @click.pass_context
-def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, no_strict, command_style):
+def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, no_strict, add_predefined_macros,
+        use_full_path, command_style):
     """Clang's Compilation Database generator for make-based build systems.
        When no subcommand is used it will parse build log/commands and generates
        its corresponding Compilation database."""
     log_level = logging.DEBUG if verbose else logging.ERROR
     logging.basicConfig(level=log_level, format=None)
     if ctx.invoked_subcommand is None:
-        done = generate(infile, outfile, build_dir, exclude_files, overwrite, not no_strict, command_style)
+        done = generate(infile, outfile, build_dir, exclude_files, overwrite, not no_strict, add_predefined_macros,
+                        use_full_path, command_style)
         exit(0 if done else 1)
     else:
         ctx.obj = Options(infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, not no_strict,
-                          command_style)
+                          add_predefined_macros, use_full_path, command_style)
 
 
 # Add subcommands

--- a/compiledb/commands/make.py
+++ b/compiledb/commands/make.py
@@ -3,18 +3,11 @@ import os
 import stat
 import tempfile
 
-from subprocess import call, PIPE, Popen
-from sys import exit, stdout, stderr, version_info
+from subprocess import call, PIPE
+from sys import exit, stdout, stderr
 
 from compiledb import generate
-
-
-if version_info.major >= 3 and version_info.minor >= 6:
-    def popen(cmd, encoding='utf-8', **kwargs):
-        return Popen(cmd, encoding=encoding, **kwargs)
-else:  # Python 2 and Python <= 3.5
-    def popen(cmd, encoding='utf-8', **kwargs):
-        return Popen(cmd, **kwargs)
+from compiledb.utils import popen
 
 
 class AutoconfMockScript:

--- a/compiledb/compiler.py
+++ b/compiledb/compiler.py
@@ -1,0 +1,123 @@
+import logging
+import os
+from subprocess import PIPE
+
+from shutilwhich import which
+
+from compiledb.utils import popen
+
+_logger = logging.getLogger(__name__)
+
+
+class Compiler:
+    def __init__(self, name="gcc"):
+        # Name of the compiler executable
+        self._name = name
+
+        # Full path to the compiler executable
+        self._full_path = self._find_full_path()
+
+        # Supported languages by the compiler
+        self._languages = {
+            "c": {
+                "extensions": ["c"]
+            },
+            "c++": {
+                "extensions": ["cpp", "cc", "cx", "cxx"],
+            },
+        }
+
+        # Keep a list of macros for each language since, for example, gcc can be used both for C and C++ sources.
+        self._predefined_macros = {
+            # language: ["-DMACRO1", "-DMACRO2=1"]
+        }
+
+    def __str__(self):
+        return self.name
+
+    def _find_full_path(self):
+        """Get a full path to the compiler executable."""
+        full_path = which(self.name)
+
+        if full_path is None:
+            full_path = self.name
+
+        return full_path
+
+    def _get_language(self, arguments, source_file):
+        """Attempt to find the language from flags or the source name."""
+        default = "c"
+
+        for arg_idx, arg in enumerate(arguments):
+            if arg == "-x" and arg_idx < len(arguments) - 1:
+                return arguments[arg_idx + 1]
+
+            if "-std=" in arg:
+                if "++" in arg:
+                    return "c++"
+                else:
+                    return default
+
+        _, extension = os.path.splitext(source_file)
+
+        if extension in self._languages["c++"]["extensions"]:
+            return "c++"
+        else:
+            return default
+
+    def _add_predefined_macros(self, language):
+        """Add a list of macros predefined by the compiler for future use."""
+        self._predefined_macros[language] = []
+        # Dump all predefined compiler macros
+        cmd = "echo | " + self.name + " -x " + language + " -dM -E -"
+
+        try:
+            pipe = popen(cmd, stdout=PIPE)
+        except (OSError, ValueError) as e:
+            _logger.error(e)
+            return
+
+        for line in pipe.stdout:
+            columns = line.split()
+            size = len(columns)
+
+            if size <= 1:
+                continue
+            elif size == 2:
+                def_arg = "-D" + columns[1]
+            else:
+                def_arg = "-D" + columns[1] + "=" + " ".join(columns[2:])
+
+            self._predefined_macros[language].append(def_arg)
+
+        pipe.wait()
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def full_path(self):
+        return self._full_path
+
+    def get_predefined_macros(self, arguments, source_file):
+        """Return a list of macros predefined by the compiler."""
+        language = self._get_language(arguments, source_file)
+
+        if language not in self._predefined_macros:
+            self._add_predefined_macros(language)
+
+        return self._predefined_macros[language]
+
+
+_compilers = []
+
+
+def get_compiler(name):
+    c = next((compiler for compiler in _compilers if name == compiler.name), None)
+
+    if c is None:
+        c = Compiler(name)
+        _compilers.append(c)
+
+    return c

--- a/compiledb/utils.py
+++ b/compiledb/utils.py
@@ -1,0 +1,15 @@
+import subprocess
+from sys import version_info
+
+if version_info.major >= 3 and version_info.minor >= 6:
+    def popen(cmd, encoding='utf-8', **kwargs):
+        return subprocess.Popen(cmd, encoding=encoding, shell=True, **kwargs)
+
+    def run_cmd(cmd, encoding='utf-8', **kwargs):
+        return subprocess.check_output(cmd, encoding=encoding, **kwargs)
+else:  # Python 2 and Python <= 3.5
+    def popen(cmd, encoding='utf-8', **kwargs):
+        return subprocess.Popen(cmd, shell=True, **kwargs)
+
+    def run_cmd(cmd, encoding='utf-8', **kwargs):
+        return subprocess.check_output(cmd, **kwargs)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,7 @@
 attrs==18.1.0
 bashlex==0.12
 click==7.0
+shutilwhich==1.1.0
 enum34==1.1.6
 more-itertools==4.1.0
 pluggy==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
         'click',
-        'bashlex'
+        'bashlex',
+        'shutilwhich'
     ],
     extras_require={
         'dev': [],


### PR DESCRIPTION
Both of these arguments improve the workflow with [rtags](https://github.com/Andersbakken/rtags).

`--macro` (`-m`) appends a list of predefined compiler macros to the end of
"arguments" section in compilation database.

This argument is useful when working with codebase that has a lot of
directives like these:
```#if defined(__arch1__) || defined(__arch2__)```
If they are not explicitly defined, the code in those `#if`s
won't be added to the rtags database.

`--full-path` searches the user's `$PATH` for the compiler executable and in
case it's found, replaces the executable name with the full path to
executable in "arguments" section in compilation database.

This argument allows to specify the compiler path only once, when
calling `compiledb`, like so:
```PATH=/opt/buildroot/bin:$PATH compiledb --full-path make```
After that no additional configuration is needed for
`rtags` and one `rdm` service can be used to handle separate projects with
separate compilers in separate `PATH`s.