### PR TITLE
Fix popen call to run make

### DIFF
--- a/compiledb/commands/make.py
+++ b/compiledb/commands/make.py
@@ -7,7 +7,7 @@ from subprocess import call, PIPE
 from sys import exit, stdout, stderr
 
 from compiledb import generate
-from compiledb.utils import popen
+from compiledb.utils import popen, cmd_join
 
 
 class AutoconfMockScript:
@@ -92,7 +92,7 @@ def command(ctx, make_cmd, make_args):
         cmd = [make_cmd, logging_mode_flags] + list(make_args)
         if mock_script.path:
             cmd.append("SHELL={}".format(mock_script.path))
-        pipe = popen(cmd, stdout=PIPE)
+        pipe = popen(cmd_join(cmd), stdout=PIPE)
         options.infile = pipe.stdout
         del args['verbose']
         done = generate(**args)

--- a/compiledb/utils.py
+++ b/compiledb/utils.py
@@ -13,3 +13,12 @@ else:  # Python 2 and Python <= 3.5
 
     def run_cmd(cmd, encoding='utf-8', **kwargs):
         return subprocess.check_output(cmd, **kwargs)
+
+try:
+    from shlex import quote as cmd_quote
+except ImportError:
+    from pipes import quote as cmd_quote
+
+
+def cmd_join(cmd):
+    return ' '.join(cmd_quote(s) for s in cmd)


### PR DESCRIPTION
When running `make` via `utils.popen`, there is an implicit `shell=True` which means you should pass the command as a string, not a list.

However, the `make` command was a list, which led to this command being handled incorrectly.  The arguments to make were instead treated as arguments to the shell, which meant that `make` did not behave as intended.  In particular, `-n` would be missing, so `make` would actually build everything even though it shouldn't.

Fix this by converting the list to a string for this `popen` call.  To support this, added a new utility function `cmd_join`, which is essentially [`shlex.join`](https://docs.python.org/dev/library/shlex.html#shlex.join) from the standard library (but a homebrew version because `shlex.join` didn't appear until Python 3.8).