### PR TITLE
Adds support for .c++ file extension

### DIFF
--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -28,7 +28,7 @@ from compiledb.utils import run_cmd
 # Internal variables used to parse build log entries
 cc_compile_regex = re.compile(r"^.*-?g?cc-?[0-9.]*$|^.*-?clang-?[0-9.]*$")
 cpp_compile_regex = re.compile(r"^.*-?[gc]\+\+-?[0-9.]*$|^.*-?clang\+\+-?[0-9.]*$")
-file_regex = re.compile(r"^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.s$", re.IGNORECASE)
+file_regex = re.compile(r"^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.c\+\+$|^.+\.s$", re.IGNORECASE)
 compiler_wrappers = {"ccache", "icecc", "sccache"}
 
 # Leverage `make --print-directory` option


### PR DESCRIPTION
I sometimes use the extension .c++ for my C++ source files. This is the patch I apply locally when I need compiledb in those projects. It would be nice to have upstream.

Thank you for your time.