### PR TITLE
Support for Posix shell emulation (MSYS, Cygwin) pathname conven…

### DIFF
--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -99,7 +99,7 @@ def merge_compdb(compdb, new_compdb, check_files=True, win_posix_shell=None):
 
 
 def generate(infile, outfile, build_dir, exclude_files, overwrite=False, strict=False,
-             add_predefined_macros=False, use_full_path=False, command_style=False, 
+             add_predefined_macros=False, use_full_path=False, command_style=False,
              win_posix_shell=None):
     try:
         r = generate_json_compdb(infile, proj_dir=build_dir, exclude_files=exclude_files,

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -36,7 +36,8 @@ class Options(object):
     shared by all compiledb subcommands"""
 
     def __init__(self, infile, outfile, build_dir, exclude_files, no_build,
-                 verbose, overwrite, strict, add_predefined_macros, use_full_path, command_style):
+                 verbose, overwrite, strict, add_predefined_macros, use_full_path, command_style,
+                 win_posix_shell):
         self.infile = infile
         self.outfile = outfile
         self.build_dir = build_dir
@@ -48,6 +49,7 @@ class Options(object):
         self.add_predefined_macros = add_predefined_macros
         self.use_full_path = use_full_path
         self.command_style = command_style
+        self.win_posix_shell = win_posix_shell
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
@@ -79,9 +81,11 @@ class Options(object):
 @click.option('--command-style', is_flag=True, default=False,
               help='Output compilation database with single "command" '
               'string rather than the default "arguments" list of strings.')
+@click.option('--win-posix-shell', 'win_posix_shell', type=click.Choice(['msys', 'cygwin'], case_sensitive=False), default=None,
+              help='Allowing for special pathname conventions of windows Posix shell envs.')
 @click.pass_context
 def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, no_strict, add_predefined_macros,
-        use_full_path, command_style):
+        use_full_path, command_style, win_posix_shell):
     """Clang's Compilation Database generator for make-based build systems.
        When no subcommand is used it will parse build log/commands and generates
        its corresponding Compilation database."""
@@ -89,11 +93,11 @@ def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overw
     logging.basicConfig(level=log_level, format=None)
     if ctx.invoked_subcommand is None:
         done = generate(infile, outfile, build_dir, exclude_files, overwrite, not no_strict, add_predefined_macros,
-                        use_full_path, command_style)
+                        use_full_path, command_style, win_posix_shell)
         exit(0 if done else 1)
     else:
         ctx.obj = Options(infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, not no_strict,
-                          add_predefined_macros, use_full_path, command_style)
+                          add_predefined_macros, use_full_path, command_style, win_posix_shell)
 
 
 # Add subcommands

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -81,11 +81,12 @@ class Options(object):
 @click.option('--command-style', is_flag=True, default=False,
               help='Output compilation database with single "command" '
               'string rather than the default "arguments" list of strings.')
-@click.option('--win-posix-shell', 'win_posix_shell', type=click.Choice(['msys', 'cygwin'], case_sensitive=False), default=None,
+@click.option('--win-posix-shell', 'win_posix_shell', type=click.Choice(['msys', 'cygwin'], 
+              case_sensitive=False), default=None,
               help='Allowing for special pathname conventions of windows Posix shell envs.')
 @click.pass_context
-def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, no_strict, add_predefined_macros,
-        use_full_path, command_style, win_posix_shell):
+def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, 
+        no_strict, add_predefined_macros, use_full_path, command_style, win_posix_shell):
     """Clang's Compilation Database generator for make-based build systems.
        When no subcommand is used it will parse build log/commands and generates
        its corresponding Compilation database."""

--- a/compiledb/cli.py
+++ b/compiledb/cli.py
@@ -81,11 +81,11 @@ class Options(object):
 @click.option('--command-style', is_flag=True, default=False,
               help='Output compilation database with single "command" '
               'string rather than the default "arguments" list of strings.')
-@click.option('--win-posix-shell', 'win_posix_shell', type=click.Choice(['msys', 'cygwin'], 
+@click.option('--win-posix-shell', 'win_posix_shell', type=click.Choice(['msys', 'cygwin'],
               case_sensitive=False), default=None,
               help='Allowing for special pathname conventions of windows Posix shell envs.')
 @click.pass_context
-def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite, 
+def cli(ctx, infile, outfile, build_dir, exclude_files, no_build, verbose, overwrite,
         no_strict, add_predefined_macros, use_full_path, command_style, win_posix_shell):
     """Clang's Compilation Database generator for make-based build systems.
        When no subcommand is used it will parse build log/commands and generates

--- a/compiledb/utils.py
+++ b/compiledb/utils.py
@@ -25,9 +25,8 @@ def cmd_join(cmd):
     return ' '.join(cmd_quote(s) for s in cmd)
 
 
-
-_cygdrive_prefix = "/cygdrive/"
-_len_cygdrive_prefix = len(_cygdrive_prefix)
+_CYGDRIVE_PREFIX = "/cygdrive/"
+_LEN_CYGDRIVE_PREFIX = len(_CYGDRIVE_PREFIX)
 
 
 def to_native_pathname(pathname, win_posix_shell):
@@ -37,14 +36,12 @@ def to_native_pathname(pathname, win_posix_shell):
             return pathname[1] + ':' + pathname[2:]
     elif win_posix_shell == "cygwin":
         # Cygwin "/cygdrive" convention
-        if pathname.startswith(_cygdrive_prefix):
-            prefix_len = len(cydrive_prefix)
-            return pathname[_len_cygdrive_prefix+1] + ':' + pathname[_len_cygdrive_prefix+2:]
+        if pathname.startswith(_CYGDRIVE_PREFIX):
+            return pathname[_LEN_CYGDRIVE_PREFIX+1] + ':' + pathname[_LEN_CYGDRIVE_PREFIX+2:]
     else:
         return pathname
 
 
-def joined_native_pathname(dir, pathname, win_posix_shell):
-   
+def joined_native_pathname(dir_pathname, pathname, win_posix_shell):
     pathname = to_native_pathname(pathname, win_posix_shell)
-    return os.path.join(dir, pathname)
+    return os.path.join(dir_pathname, pathname)

--- a/compiledb/utils.py
+++ b/compiledb/utils.py
@@ -1,5 +1,6 @@
 import subprocess
 from sys import version_info
+import os
 
 if version_info.major >= 3 and version_info.minor >= 6:
     def popen(cmd, encoding='utf-8', **kwargs):
@@ -22,3 +23,28 @@ except ImportError:
 
 def cmd_join(cmd):
     return ' '.join(cmd_quote(s) for s in cmd)
+
+
+
+_cygdrive_prefix = "/cygdrive/"
+_len_cygdrive_prefix = len(_cygdrive_prefix)
+
+
+def to_native_pathname(pathname, win_posix_shell):
+    if win_posix_shell == "msys":
+        # MSYS drive-letter convention.
+        if len(pathname) > 2 and pathname[0] == '/' and pathname[2] == '/':
+            return pathname[1] + ':' + pathname[2:]
+    elif win_posix_shell == "cygwin":
+        # Cygwin "/cygdrive" convention
+        if pathname.startswith(_cygdrive_prefix):
+            prefix_len = len(cydrive_prefix)
+            return pathname[_len_cygdrive_prefix+1] + ':' + pathname[_len_cygdrive_prefix+2:]
+    else:
+        return pathname
+
+
+def joined_native_pathname(dir, pathname, win_posix_shell):
+   
+    pathname = to_native_pathname(pathname, win_posix_shell)
+    return os.path.join(dir, pathname)


### PR DESCRIPTION
The final pasting of working dir and captured filenames from make output uses python native pathname joining.  This cannot allow for the special pathname conventions Posix shell environments (MSYS, cygwin) use to handle Windows drive-letters.
This PR allows the shell environment being used to be specified and adjusts pathname pasting to create a legal Windows pathname.