### PR TITLE
Fix potential KeyError in merge_compdb()

### DIFF
--- a/compiledb/__init__.py
+++ b/compiledb/__init__.py
@@ -87,7 +87,7 @@ def merge_compdb(compdb, new_compdb, check_files=True):
     def gen_key(entry):
         if 'directory' in entry:
             return os.path.join(entry['directory'], entry['file'])
-        return entry['directory']
+        return entry['file']
 
     def check_file(path):
         return True if not check_files else os.path.exists(path)


### PR DESCRIPTION
At the point where `entry['directory']` is used, `'directory'` is definitely not in `entry` as checked in `if` two lines above. On the other hand, `'file'` is guaranteed to be in `entry`, because `gen_key(c)` is called only `if 'file' in c`. This looks like a "typo".