### PR TITLE
Fixing Path Parse Failed On Windows

### DIFF
--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -256,6 +256,6 @@ class CommandProcessor(bashlex.ast.nodevisitor):
 
 
 def unescape(s):
-    return s.encode().decode('unicode_escape')
+    return repr(s).encode().decode('unicode_escape')
 
 # ex: ts=2 sw=4 et filetype=python


### PR DESCRIPTION
Description：
I found that compiledb can't work on windows any more.And I discovered an open issue [Here](https://github.com/nickdiego/compiledb/issues/124#issue-1346743559).So I just fixed it.
Modification：
on parser.py line259：
change return s.encode().decode('unicode_escape') to return repr(s).encode().decode('unicode_escape')