### PR TITLE
Support QNX compiler

### DIFF
--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -26,8 +26,8 @@ from compiledb.compiler import get_compiler
 from compiledb.utils import run_cmd
 
 # Internal variables used to parse build log entries
-cc_compile_regex = re.compile(r"^.*-?g?cc-?[0-9.]*$|^.*-?clang-?[0-9.]*$")
-cpp_compile_regex = re.compile(r"^.*-?[gc]\+\+-?[0-9.]*$|^.*-?clang\+\+-?[0-9.]*$")
+cc_compile_regex = re.compile(r"^.*-?[gq]?cc-?[0-9.]*$|^.*-?clang-?[0-9.]*$")
+cpp_compile_regex = re.compile(r"^.*-?[gcq]\+\+-?[0-9.]*$|^.*-?clang\+\+-?[0-9.]*$")
 file_regex = re.compile(r"^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.s$", re.IGNORECASE)
 compiler_wrappers = {"ccache", "icecc", "sccache"}
 


### PR DESCRIPTION
Update the compiler detection regular expression to recognize C and C++ compilers in QNX tool chain (qcc and q++).

CLI interface [1] of QNX compilers are extremely similar to that of GCC and CLang. 



[1] - https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.utilities/topic/q/qcc.html