### PR TITLE
shutil.which already present in modern python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 3
 jobs:
   build:
     docker:
-      - image: circleci/python:3.11-bookworm
+      - image: circleci/python:3.11
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2
+version: 3
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6-jessie
+      - image: circleci/python:3.11-bookworm
 
     working_directory: ~/repo
 

--- a/compiledb/compiler.py
+++ b/compiledb/compiler.py
@@ -2,7 +2,7 @@ import logging
 import os
 from subprocess import PIPE
 
-from shutilwhich import which
+from shutil import which
 
 from compiledb.utils import popen
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,6 @@
 attrs==18.1.0
 bashlex==0.12
 click==7.0
-shutilwhich==1.1.0
 enum34==1.1.6
 more-itertools==4.1.0
 pluggy==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     install_requires=[
         'click',
         'bashlex',
-        'shutilwhich'
     ],
     extras_require={
         'dev': [],

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,8 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.11',
         'Operating System :: OS Independent'
     ],
     keywords='compilation-database clang c cpp makefile rtags completion',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py36,lint
+envlist = py311,lint
 
 [pycodestyle]
 ignore = E226, W504


### PR DESCRIPTION
I was working on OpenBSD port when realised that I can push that change to upstream
https://github.com/artsi0m/porting-efforts/tree/5be6fa89586ad56941700ea22f3a99d33d9f26dd/devel/py-compiledb/patches

Modern python has which function inside the shutil module, so you probably don't need shutilwhich any more.  